### PR TITLE
Add unknown class name to deserialization error

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -1,0 +1,28 @@
+import SuperJSON from './index.js';
+
+import { test, expect } from 'vitest';
+
+test('throws an descriptive error when transforming', () => {
+  const instance = new SuperJSON();
+  class FunnyNumber {
+    constructor(private number: number) {}
+
+    // @ts-ignore
+    get theNumber() {
+      return this.number;
+    }
+  }
+  instance.registerClass(FunnyNumber);
+  expect(() =>
+    instance.deserialize({
+      json: instance.serialize({
+        number: new FunnyNumber(2137),
+      }).json,
+      meta: {
+        values: [['class', 'NotRegistered']],
+      },
+    })
+  ).toThrowError(
+    `Trying to deserialize unknown class 'NotRegistered' - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
+  );
+});

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -275,7 +275,7 @@ const classRule = compositeTransformation(
 
     if (!clazz) {
       throw new Error(
-        `Trying to deserialize unknown class - ${a[1]} - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
+        `Trying to deserialize unknown class '${a[1]}' - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
       );
     }
 

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -275,7 +275,7 @@ const classRule = compositeTransformation(
 
     if (!clazz) {
       throw new Error(
-        'Trying to deserialize unknown class - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564'
+        `Trying to deserialize unknown class - ${a[1]} - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
       );
     }
 


### PR DESCRIPTION
This pull request includes a small change to the `src/transformer.ts` file. The change modifies the error message to include the class name being deserialized. 

* [`src/transformer.ts`](diffhunk://#diff-df7446068188621a3fa66e02d4e5c9081902f1bb2cd9092e06c59271978257d3L278-R278): Updated the error message in the `classRule` function to include the class name that is being deserialized.